### PR TITLE
Fix can't find variable: AUDIO_SPEAKER

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,10 +21,10 @@ export default class RNSwitchAudioOutput {
 
   static selectAudioOutput = (audioOutput) => {
     switch (audioOutput) {
-      case AUDIO_SPEAKER:
+      case this.AUDIO_SPEAKER:
         ReactNativeSwitchAudioOutput.switchAudioOutput(true);
         break;
-      case AUDIO_HEADPHONE:
+      case this.AUDIO_HEADPHONE:
         ReactNativeSwitchAudioOutput.switchAudioOutput(false);
         break;
       default:


### PR DESCRIPTION
Before i was using your library on 1.0.3 and everything was fine. After updating to 1.1.1 I got the deprecation warning. 

So I changed the function invocation according to your readme to 

`RNSwitchAudioOutput.selectAudioOutput(RNSwitchAudioOutput.AUDIO_SPEAKER)`

But then I got the following error:

`Fix can't find variable: AUDIO_SPEAKER while trying go switch to audio speaker `

Adding `this` fixed the problem for me.